### PR TITLE
Fix misc bugs with custom resolution using mergetool

### DIFF
--- a/CsMerge.Core/Core/SerialisationHelper.cs
+++ b/CsMerge.Core/Core/SerialisationHelper.cs
@@ -54,6 +54,10 @@ namespace CsMerge.Core {
           return new ProjectReference( include,
                                        Guid.Parse( itemElement.Element( xNamespace.GetName( "Project" ) ).Value ),
                                        itemElement.Element( xNamespace.GetName( "Name" ) ).Value, itemElement );
+        
+        case "PackageReference":
+          return new Project.PackageReference( itemElement );
+        
         default:
           return new RawItem( itemElement, include );
       }

--- a/NuGetHelpers/GitHelper.cs
+++ b/NuGetHelpers/GitHelper.cs
@@ -18,7 +18,18 @@ namespace Integration {
     public static string GetMergeCmdLine( Repository repository ) {
       ConfigurationEntry<string> mergeToolName = repository.Config.Get<string>( "merge.tool" );
       var cmd = repository.Config.Get<string>( "mergetool." + mergeToolName.Value + ".cmd" );
-      return cmd.Value;
+
+      if ( cmd != null ) {
+        return cmd.Value;
+      }
+
+      var path = repository.Config.Get<string>( "mergetool." + mergeToolName.Value + ".path" );
+
+      if ( path != null ) {
+        return $"\"{path.Value}\" \"$REMOTE\" \"$LOCAL\" \"$BASE\" \"$MERGED\"";
+      }
+
+      throw new InvalidOperationException( "Could not identify git merge tool command. Please configure it in git config." );
     }
 
     private static int RunStandardMergetool( Repository repository, string @base, string local, string incoming, string resolved ) {


### PR DESCRIPTION
1. Enable resolution using mergetool when no mergetool cmd is configured in git config (see [Issue 23](https://github.com/configit-open-source/csmerge/issues/23) ).
2. Fix bug with custom resolution of package references