### PR TITLE
Fix a bug dealing with project references where optional elements are not specified

### DIFF
--- a/CsMerge.Core/Core/SerialisationHelper.cs
+++ b/CsMerge.Core/Core/SerialisationHelper.cs
@@ -51,9 +51,7 @@ namespace CsMerge.Core {
           return new Reference( itemElement );
 
         case "ProjectReference":
-          return new ProjectReference( include,
-                                       Guid.Parse( itemElement.Element( xNamespace.GetName( "Project" ) ).Value ),
-                                       itemElement.Element( xNamespace.GetName( "Name" ) ).Value, itemElement );
+          return ProjectReference.Deserialize( itemElement );
         
         case "PackageReference":
           return new Project.PackageReference( itemElement );

--- a/Project/ProjectReference.cs
+++ b/Project/ProjectReference.cs
@@ -3,14 +3,16 @@ using System.Collections.Generic;
 using System.Xml.Linq;
 
 namespace Project {
-  public class ProjectReference: RawItem, IEquatable<ProjectReference> {
-    public string CsProjPath { get; private set; }
-    public Guid ProjectId { get; private set; }
-    public string Name { get; private set; }
 
-    public override string Key {
-      get { return ProjectId.ToString(); }
-    }
+  public class ProjectReference: RawItem, IEquatable<ProjectReference> {
+    
+    private readonly bool _hasName;
+
+    public string CsProjPath { get; }
+
+    public Guid? ProjectId { get; }
+
+    public string Name { get; }
 
     public override bool Equals( Item other ) {
       return Equals( (object) other );
@@ -23,19 +25,31 @@ namespace Project {
 
       var e = new XElement( ns.GetName( Action ) );
       e.Add( new XAttribute( "Include", CsProjPath ) );
-      e.Add( new XElement( ns.GetName( "Project" ), "{" + ProjectId + "}" ) );
-      e.Add( new XElement( ns.GetName( "Name" ), Name ) );
+
+      if ( ProjectId.HasValue ) {
+        e.Add( new XElement( ns.GetName( "Project" ), "{" + ProjectId.Value + "}" ) );
+      }
+
+      if ( _hasName ) {
+        e.Add( new XElement( ns.GetName( "Name" ), Name ) );
+      }
+
       return e;
     }
 
     public bool Equals( ProjectReference other ) {
+
       if ( ReferenceEquals( null, other ) ) {
         return false;
       }
+
       if ( ReferenceEquals( this, other ) ) {
         return true;
       }
-      return string.Equals( CsProjPath, other.CsProjPath ) && ProjectId.Equals( other.ProjectId ) && string.Equals( Name, other.Name );
+
+      return string.Equals( CsProjPath, other.CsProjPath )
+             && string.Equals( Name, other.Name )
+             && ProjectId == other.ProjectId;
     }
 
     public override bool Equals( object obj ) {
@@ -60,9 +74,17 @@ namespace Project {
       }
     }
 
-    public ProjectReference( string csProjPath, Guid project, string name, XElement element ) 
-      : base( element, project.ToString() ) {
-      Name = name;
+    public ProjectReference( string csProjPath, Guid? project, string name, XElement element )
+      : base( element, project?.ToString() ?? csProjPath ) {
+      
+      if ( string.IsNullOrEmpty( name ) ) {
+        Name = CsProjPath.Contains( "\\" ) ? csProjPath.Substring( csProjPath.LastIndexOf( '\\' ) + 1 ) : csProjPath;
+      }
+      else {
+        Name = name;
+        _hasName = true;
+      }
+      
       ProjectId = project;
       CsProjPath = csProjPath;
     }
@@ -76,6 +98,25 @@ namespace Project {
       propertyNames.AddPropertyIfNotNull( CsProjPath, "Path" );
 
       return string.Join( Environment.NewLine, propertyNames );
+    }
+
+    public static ProjectReference Deserialize( XElement element ) {
+
+      var includeAttribute = element.Attribute( "Include" );
+
+      if ( includeAttribute == null ) {
+        return null;
+      }
+
+      var include = includeAttribute.Value;
+
+      var xNamespace = element.Name.Namespace;
+
+      var projectElement = element.Element( xNamespace.GetName( "Project" ) )?.Value;
+      var project = projectElement == null ? (Guid?) null : Guid.Parse( projectElement );
+      var name = element.Element( xNamespace.GetName( "Name" ) )?.Value;
+
+      return new ProjectReference( include, project, name, element );
     }
   }
 }

--- a/Project/SerialisationHelper.cs
+++ b/Project/SerialisationHelper.cs
@@ -51,9 +51,8 @@ namespace Project {
           return new PackageReference( itemElement );
 
         case "ProjectReference":
-          return new ProjectReference( include,
-                                       Guid.Parse( itemElement.Element( xNamespace.GetName( "Project" ) ).Value ),
-                                       itemElement.Element( xNamespace.GetName( "Name" ) ).Value, itemElement );
+          return ProjectReference.Deserialize( itemElement );
+
         //case "Compile":
         //  return new FileIncludeItem( itemElement, include );
         default:


### PR DESCRIPTION
According to [Microsoft documentation](https://docs.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-items?view=vs-2019), the ProjectReference attributes `Name` and `Project` are optional.

If they are not specified, the application fails.

This change prevents the exception.