### PR TITLE
Improve user question when node conflict is not auto-resolved

### DIFF
--- a/Project/Item.cs
+++ b/Project/Item.cs
@@ -32,7 +32,8 @@ namespace Project {
     public abstract XElement ToElement( XNamespace ns );
 
     public override string ToString() {
-      return Key;
+      var element = ToElement( "" );
+      return element?.ToString() ?? Key;
     }
   }
 }


### PR DESCRIPTION
When a csproj node is not auto-resolvable, CsMerge asks the user what they want to do, but it uses the nodes `ToString()` method to get a string representation of each option to display to the user. 

Currently, this is the nodes key, so the question looks something like this:

![image](https://user-images.githubusercontent.com/11267784/83724020-800d7880-a637-11ea-9ea2-27d2aeaaa335.png)

This isn't very helpful, as the key is by definition the same (its how it matches nodes), and it leaves out the details that would help you choose a side they want.

Hence, I have changed the `ToString()` method to return the xml representation, rather than the key, so it displays the actual option to the user. The question now looks something like this:

![image](https://user-images.githubusercontent.com/11267784/83723386-864f2500-a636-11ea-87f9-659684d9ab96.png)
